### PR TITLE
Fix recentBlockhashes Bug

### DIFF
--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -438,7 +438,7 @@ export const mintOneToken = async (
         systemProgram: SystemProgram.programId,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
         clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
-        recentBlockhashes: anchor.web3.SYSVAR_SLOT_HASHES_PUBKEY,
+        recentBlockhashes: new anchor.web3.PublicKey('SysvarS1otHashes111111111111111111111111111'),
         instructionSysvarAccount: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
       },
       remainingAccounts:


### PR DESCRIPTION
Fix recentBlockhashes Bug, found on line 441. Causing error : 

Property 'SYSVAR_SLOT_HASHES_PUBKEY' does not exist on type 'typeof import("@solana/web3.js")'.  TS2339

Kept Candy Machine site from compiling properly.